### PR TITLE
[BUG] Exclude self from update_all to ensure following changes work properly

### DIFF
--- a/app/models/accounting/payment.rb
+++ b/app/models/accounting/payment.rb
@@ -59,7 +59,7 @@ module Accounting
 
     def default!
       if profile.present? && !profile.destroyed?
-        profile.payments.where(default: true).update_all(default: false)
+        profile.payments.where(default: true).where.not(id: id).update_all(default: false)
         update_attribute(:default, true) unless destroyed?
       end
     end

--- a/spec/models/accounting/payment_spec.rb
+++ b/spec/models/accounting/payment_spec.rb
@@ -19,12 +19,25 @@ RSpec.describe Accounting::Payment, type: :model do
     end
   end
 
-  it 'should be the default payment if first payment method' do
-    VCR.use_cassette :valid_payment, record: :new_episodes, re_record_interval: 7.days do
-      expect(payment.profile.payments.count).to eq(0)
-      payment.save!
-      expect(payment.profile.payments.count).to eq(1)
-      expect(payment.default?).to be_truthy
+  describe 'default payment' do
+    it 'should be the default payment if first payment method' do
+      VCR.use_cassette :valid_payment, record: :new_episodes, re_record_interval: 7.days do
+        expect(payment.profile.payments.count).to eq(0)
+        payment.save!
+        expect(payment.profile.payments.count).to eq(1)
+        expect(payment.default?).to be_truthy
+      end
+    end
+
+    it 'should make default payment when default! called' do
+      VCR.use_cassette :valid_payment, record: :new_episodes, re_record_interval: 7.days do
+        payment.save!
+        expect(payment.default?).to be_truthy
+        payment2 = FactoryGirl.create(:accounting_payment, :with_card, profile: payment.profile)
+        payment2.default!
+        expect(payment.reload.default?).to be_falsey
+        expect(payment2.reload.default?).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
update_all doesn't update loaded records. It only runs single sql. Here, update_attribute won't run when self.default is already true despite it is false in the database. So we are excluding self from update_all.