### PR TITLE
[CHG] Change source of authorizenet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
-source 'https://gem.minow.io' do
-  # Stupid, but Authorize.NET fails to maintain their own gem
-  # so we have to do it separately
-  gem 'authorizenet', '~> 1.9.5'
-end
+
+gem 'authorizenet', git: 'https://github.com/CKDev/sdk-ruby.git'
 
 # Specify your gem's dependencies in accounting.gemspec
 gemspec


### PR DESCRIPTION
We were using the forked authorizenet gem from the minow server, but
need to make changes to the code.  I'm moving that to the same version
of code, but on the ckdev organization.