### PR TITLE
[BUG] Don't attempt to sync test transactions

### DIFF
--- a/app/services/accounting/transaction_service.rb
+++ b/app/services/accounting/transaction_service.rb
@@ -4,6 +4,9 @@ module Accounting
     include AccountingHelper
 
     def sync!
+      # Ignore verification transactions
+      return if resource.order&.description == 'Test transaction for ValidateCustomerPaymentProfile.'
+
       # Ensure the transaction has the associated profile and payment associated
       resource.profile_id ||= profile.id
       resource.payment_id ||= payment.id


### PR DESCRIPTION
Authorize sends a transaction webhook when authorizing a new payment methods with a microtransaction. It uses a placeholder customer email, so the transaction can't sync to a customer profile and raises an Accounting::SyncWarning. We shouldn't attempt to sync these test transactions anyway.

Fixes issue #7 