### PR TITLE
Reliable resource lookup

### DIFF
--- a/app/services/accounting/transaction_service.rb
+++ b/app/services/accounting/transaction_service.rb
@@ -41,7 +41,9 @@ module Accounting
     end
 
     def resource
-      @resource ||= Accounting::Transaction.find_by(transaction_id: payload[:id])
+      # where().first is used here to make sure we get the first Accounting::Transaction
+      # according to resource ID every time
+      @resource ||= Accounting::Transaction.where(transaction_id: payload[:id]).first
     end
 
     def type

--- a/spec/models/accounting/subscription_spec.rb
+++ b/spec/models/accounting/subscription_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Accounting::Subscription, type: :model do
   let!(:user) { FactoryBot.create(:user) }
   let!(:payment) { FactoryBot.build(:accounting_payment, :with_card, profile: user.profile) }
 
-  before :each { skip }
+  before(:each) { skip }
 
   it 'should support instantiation' do
     expect(Accounting::Subscription.new).to be_instance_of(Accounting::Subscription)


### PR DESCRIPTION
`find_by` doesn't ensure ordering.

We were seeing a bug in voids where the original transaction was not properly updated when it was voided. This is because the "void transaction" and "original transaction" both have the same `transaction_id`. When webhooks come in, they trigger the `TransactionService`'s `#sync!` method, which updates an `Accounting::Transaction` to match what's in Authorize. The resource that needs to be updated in the case of voids is the "original transaction", which is the FIRST transaction in the database (by primary key) with the matching `transaction_id`. With `find_by`, we weren't guaranteed to get the first transaction every time, and were sometimes updating the second "void transaction" with information from the "original transaction".