### PR TITLE
Add NSF detection service

### DIFF
--- a/app/services/accounting/nsf_service.rb
+++ b/app/services/accounting/nsf_service.rb
@@ -1,0 +1,125 @@
+module Accounting
+  class NSFService
+    include AuthorizeNet::API
+    include AccountingHelper
+
+    attr_accessor :authnet_options, :start_time, :end_time
+
+    def initialize(authnet_options, start_time, end_time)
+      raise ArgumentError, 'Start and End time can\'t be blank' if start_time.nil? || end_time.nil?
+      @authnet_options = authnet_options
+      @start_time = start_time
+      @end_time = end_time
+    end
+
+    def run(&block)
+      count = 0
+      echeck_batch_list.each do |batch|
+        # Check Statistics array for returned items
+        next unless batch.statistics.map(&:chargeReturnedItemsCount).map(&:to_i).inject(&:+).positive?
+        batch_returned_transaction_ids(batch.batchId).each do |return_trans_id|
+          set_nsf(find_original_transaction(return_trans_id), &block)
+          count += 1
+        end
+      end
+      Accounting.log('NSF', info: "Found total of #{count} NSF transactions")
+      count
+    end
+
+    private
+
+      def echeck_batch_list
+        request = GetSettledBatchListRequest.new
+        request.firstSettlementDate = start_time
+        request.lastSettlementDate = end_time
+        request.includeStatistics = true
+      
+        response = Accounting.api(:api, authnet_options).get_settled_batch_list(request)
+
+        unless response.messages.resultCode == MessageTypeEnum::Ok
+          raise Accounting::SyncWarning.new("Failed to fetch settled batch list: #{response.messages.messages[0].text}")
+        end
+
+        if response.batchList&.batch.blank?
+          Accounting.log('NSF', info: 'No settled batch list')
+          return []
+        end
+        
+        response.batchList.batch.select { |e| e.paymentMethod == 'eCheck' }
+      end
+
+      def batch_returned_transaction_ids(batch_id)
+        request = AuthorizeNet::API::GetTransactionListRequest.new
+        request.batchId = batch_id
+
+        response = Accounting.api(:api, authnet_options).get_transaction_list(request)
+
+        if response == nil || response.messages.resultCode != MessageTypeEnum::Ok || response.transactions == nil
+          raise Accounting::SyncWarning.new("Failed to fetch batch transaction list: #{response.messages.messages[0].text}")
+        end
+
+        returned_transactions = response.transactions.transaction.select { |e| e.transactionStatus == 'returnedItem' }
+        returned_transactions.map(&:transId)
+      end
+
+      def find_original_transaction(return_trans_id)
+        details = get_transaction_details(return_trans_id)
+        profile = Accounting::Profile.find_by!(authnet_id: details.transaction.customer.id)
+
+        last_four = details.payment.bankAccount.accountNumber[-4..-1]
+        payment = profile.payments.find_by!(last_four: last_four, profile_type: :ach)
+
+        get_returned_transaction_list_for_customer(profile.id, payment.id).each do |ot|
+          get_transaction_details(ot.transId).returnedItems.returnedItem.each do |returnedItem|
+            return ot.transId if returnedItem.id == return_trans_id
+          end
+        end
+        raise Accounting::SyncWarning.new("Could not find original transaction for returned transaction #{return_trans_id}")
+      end
+
+      def get_transaction_details(trans_id)
+        request = GetTransactionDetailsRequest.new
+        request.transId = trans_id
+        response = Accounting.api(:api, authnet_options).get_transaction_details(request)
+
+        if response.messages.resultCode != MessageTypeEnum::Ok
+          raise Accounting::SyncWarning.new("Failed to get transaction details: #{response.messages.messages[0].text}")
+        end
+
+        response.transaction
+      end
+
+      def get_returned_transaction_list_for_customer(profile_id, payment_id)
+        request = AuthorizeNet::API::GetTransactionListForCustomerRequest.new
+        request.customerProfileId = profile_id
+        request.customerPaymentProfileId = payment_id
+        request.paging = Paging.new
+        request.paging.limit = 20
+        request.paging.offset = 1
+
+        request.sorting = TransactionListSorting.new
+        request.sorting.orderBy = 'id'
+        request.sorting.orderDescending = true
+
+        response = Accounting.api(:api, authnet_options).get_transaction_list_for_customer(request)
+
+        if response.messages.resultCode != MessageTypeEnum::Ok || response.transactions.nil?
+          raise Accounting::SyncWarning.new("Failed to fetch transaction list for customer: #{response.messages.messages[0].text}")
+        end
+
+        response.transactions.transaction.select { |e| e.hasReturnedItems === 'true'}
+      end
+
+      def set_nsf(trans_id)
+        transaction = Accounting::Transaction.find_by(transaction_id: trans_id)
+        if transaction.present?
+          transaction.returned!
+          yield transaction if block_given?
+          Accounting.log('NSF', info: "Found NSF transaction: #{trans_id}")
+        else
+          Accounting.log('NSF', error: "Found returned transaction #{trans_id} but it's not in RL")
+        end
+      end
+
+  end
+end

--- a/app/services/accounting/transaction_service.rb
+++ b/app/services/accounting/transaction_service.rb
@@ -39,7 +39,8 @@ module Accounting
     def resource
       # where().first is used here to make sure we get the first Accounting::Transaction
       # according to resource ID every time
-      @resource ||= Accounting::Transaction.find_or_initialize_by(transaction_id: payload[:id])
+      @resource ||= Accounting::Transaction.where(transaction_id: payload[:id]).first
+      @resource ||= Accounting::Transaction.new(transaction_id: payload[:id])
     end
 
     def type

--- a/app/services/accounting/transaction_service.rb
+++ b/app/services/accounting/transaction_service.rb
@@ -2,10 +2,6 @@ module Accounting
   class TransactionService < AccountingService
 
     def sync!
-      if resource.nil? # Don't want to process orphaned profiles
-        raise Accounting::SyncError.new("Transaction cannot be created, transaction with id '#{payload[:id]}' could not be found.", payload)
-      end
-
       # Ignore verification transactions
       return if details&.order&.description == 'Test transaction for ValidateCustomerPaymentProfile.'
 
@@ -43,7 +39,7 @@ module Accounting
     def resource
       # where().first is used here to make sure we get the first Accounting::Transaction
       # according to resource ID every time
-      @resource ||= Accounting::Transaction.where(transaction_id: payload[:id]).first
+      @resource ||= Accounting::Transaction.find_or_initialize_by(transaction_id: payload[:id])
     end
 
     def type
@@ -87,10 +83,10 @@ module Accounting
     end
 
     def profile
-      if Accounting::Profile.exists?(authnet_email: details.customer.email)
-        Accounting::Profile.find_by(authnet_email: details.customer.email)
+      if Accounting::Profile.exists?(authnet_id: details.customer.id)
+        Accounting::Profile.find_by(authnet_id: details.customer.id)
       else
-        raise Accounting::SyncWarning.new("Transaction cannot be created, profile with email '#{details.customer.email}' could not be found.", payload)
+        raise Accounting::SyncWarning.new("Transaction cannot be created, profile with authnet_id '#{details.customer.id}' could not be found.", payload)
       end
     end
 


### PR DESCRIPTION
It would be good to have webhook for NSF transactions but Authnet doesn't trigger webhook for on transaction update.

But if an echeck payment is NSF, Authnet create another Transaction with transactionStauts = 'returnedItem'. I check settled batches in the past 24hours everyday and check if there's any returnedItem(NSF) transactions through the batch statistics. If any, I will fetch TransactionList and find out the NSF transaction. Authnet doesn't send original transaction id in NSF transaction details but I can get the profile and payment for the NSF transaction. So based on customer profile and payment, I fetch the last 20(we will adjust this later) transactions for this payment method and iterate through until I find the matching transaction.(The original transaction has associated returnedItem).
I have another PR in RL in CronRunner to detect NSF on daily basis.