### PR TITLE
[BUG] Allow new transactions to sync.

### DIFF
--- a/app/models/accounting/transaction.rb
+++ b/app/models/accounting/transaction.rb
@@ -50,7 +50,7 @@ module Accounting
 
     before_save :update_subscription!
 
-    delegate :accountable, to: :profile
+    delegate :accountable, to: :profile, allow_nil: true # Accountable might not exist before sync.
 
     def details(api_opts={})
       request = GetTransactionDetailsRequest.new


### PR DESCRIPTION
If a transaction (such as a refund) originates within authorize instead of redline, we don't have a record of it at first. The hook system will build a new Transaction, but that transaction sync will fail, since the new Transaction record doesn't have an accountable to which to delegate the profile. If we allow the accountable to be nil, the transactions can sync on transaction_id alone, which will update the transaction with all the information it needs, including accountable_id.