### PR TITLE
[CHG] Force encoding to UTF-8

### DIFF
--- a/app/controllers/accounting/hooks_controller.rb
+++ b/app/controllers/accounting/hooks_controller.rb
@@ -31,11 +31,11 @@ module Accounting
       end
 
       def payload
-        params.try(:to_unsafe_h) || {}
+        params.to_json.force_encoding 'UTF-8'
       end
 
       def body
-        request.body.read
+        request.body.read.force_encoding 'UTF-8'
       end
 
   end

--- a/app/jobs/accounting/hook_job.rb
+++ b/app/jobs/accounting/hook_job.rb
@@ -14,7 +14,7 @@ module Accounting
     def perform(signature, body, payload, uid)
       @signature = signature.to_s
       @body = body.to_s
-      @payload = payload
+      @payload = JSON.parse payload
       @uid = uid.to_s.downcase
       authenticate!
       hook.handle!
@@ -30,7 +30,7 @@ module Accounting
         raise Accounting::SyncError.new('Invalid signature', payload) if signature.blank?
 
         cred = Accounting.config.api_creds(uid)
-        raise Accounting::SyncError.new("Invalid uid: #{uid}", payload) if cred.blank?
+        raise Accounting::SyncWarning.new("Invalid uid: #{uid}", payload) if cred.blank?
 
         return true if signature == OpenSSL::HMAC.hexdigest('SHA512', cred[:signature], body).upcase
 

--- a/spec/controllers/accounting/hooks_controller_spec.rb
+++ b/spec/controllers/accounting/hooks_controller_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe Accounting::HooksController, type: :controller do
                        \"eventDate\":\"2018-10-18T03:09:30.2729756Z\",
                        \"webhookId\":\"eb6e1f40-9e17-4d8d-aae3-a47acc001fbc\",
                        \"payload\":{\"customerProfileId\":#{@profile.profile_id},
+                       \"description\":\"Rémy  Raleigh\",
                        \"entityName\":\"customerPaymentProfile\",
                        \"id\":#{@paymentProfile.id}}}"
   end
 
   it 'should enqueue a hook job on create' do
-    expect { post :create, params: JSON.parse(@valid_payload).merge(uid: TEST_UID) }.to have_enqueued_job(Accounting::HookJob)
+    expect { post :create, params: JSON.parse(@valid_payload).merge(uid: TEST_UID), as: :json }.to have_enqueued_job(Accounting::HookJob)
     expect(response).to have_http_status(:ok)
   end
 


### PR DESCRIPTION
Example payload to webhook endpoint:

```
{"notificationId":"a4217d5b-1763-4f32-956b-87b5061efe8d","eventType":"net.authorize.customer.created","eventDate":"2019-11-04T15:36:59.8855703Z","webhookId":"ac31bdd1-6e5f-413f-a432-426ff278c880","payload":{"merchantCustomerId":"55209-3c9ad92b","description":"Rémy Raleigh","entityName":"customerProfile","id":"1626125873"}}
```
Then it will raise error when trying to dump json and enqueue a sidekiq job
```
      "exception": {
        "message": "\"\\xC3\" from ASCII-8BIT to UTF-8", 
        "class": "Encoding::UndefinedConversionError"
      }, 
```